### PR TITLE
CASMPET-5188 Avoid building base images.

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -74,6 +74,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Sign image tags
+        if: ${{ github.event_name != 'pull_request' }}
         env:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
           IMAGE: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -3,44 +3,39 @@ name: Build image
 on:
   push:
     branches:
+      - '**'
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
       - main
-    paths:
-      - .github/workflows/build-image.yaml
-      - Dockerfile
-  schedule:
-    - cron: "0 0 * * *"
   workflow_dispatch:
 
 env:
   registry: artifactory.algol60.net/csm-docker
 
 jobs:
-  build:
+  docker:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ref:
-          - master
-          - 3.25.0
-      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
         with:
-          path: cray-hpe/nexus3
-
-      - name: Checkout sonatype/docker-nexus3
-        uses: actions/checkout@v2
-        with:
-          repository: sonatype/docker-nexus3
-          path: sonatype/docker-nexus3
-          ref: ${{ matrix.ref }}
-
-      - name: Parse Nexus version
-        id: parse-version
-        shell: bash
-        run: echo "::set-output name=version::$(grep -e '^ARG NEXUS_VERSION=' sonatype/docker-nexus3/Dockerfile | sed -e 's/^ARG NEXUS_VERSION=//' -e 's/-.*$//')"
-
+          images: ${{ env.registry }}/${{ startsWith(github.ref, 'refs/tags/v') && 'stable' || 'unstable' }}/nexus3
+          labels: |
+            org.opencontainers.image.vendor=Hewlett Packard Enterprise Development LP
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=sha,format=short,prefix=
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
@@ -70,29 +65,18 @@ jobs:
           username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
           password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
 
-      - name: Build sonatype/nexus3:${{ steps.parse-version.outputs.version }}
-        id: build-base
+      - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          context: sonatype/docker-nexus3
-          push: true
-          tags: |
-            ${{ env.registry }}/stable/docker.io/sonatype/nexus3:${{ steps.parse-version.outputs.version }}
-
-      - name: Build nexus3:${{ steps.parse-version.outputs.version }}
-        uses: docker/build-push-action@v2
-        with:
-          context: cray-hpe/nexus3
-          build-args: |
-            IMAGE=${{ env.registry }}/stable/docker.io/sonatype/nexus3:${{ steps.parse-version.outputs.version }}@${{ steps.build-base.outputs.digest }}
-          push: true
-          tags: |
-            ${{ env.registry }}/stable/nexus3:${{ steps.parse-version.outputs.version }}
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Sign image tags
         env:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
-          IMAGE: ${{ env.registry }}/stable/nexus3:${{ steps.parse-version.outputs.version }}
+          IMAGE: ${{ steps.meta.outputs.tags }}
         run: cosign sign -key $COSIGN_KEY $IMAGE
 
       # TODO: Scan image and save results

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG IMAGE=sonatype/nexus3
-FROM $IMAGE
+FROM sonatype/nexus3:3.25.0
 
 # Install the Keycloak plugin, see https://github.com/flytreeleft/nexus3-keycloak-plugin
 ARG KEYCLOAK_PLUGIN_VERSION=0.5.0
@@ -8,6 +7,11 @@ ADD https://github.com/flytreeleft/nexus3-keycloak-plugin/releases/download/v${K
 COPY keycloak-plugin/* /usr/local/bin
 
 USER root
+# This Nexus image is based on the RHEL Universal Base Image (UBI).
+# Update any base image packagess now so that we keep our Nexus image
+# current.
+RUN dnf update -y
+
 RUN curl -sfL https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
     
@@ -18,7 +22,7 @@ RUN chown nexus:nexus /opt/sonatype/nexus/deploy/nexus3-keycloak-plugin-${KEYCLO
 # will need to modify the file so it makes sense that nexus
 # should just own the file.
 RUN chown nexus:nexus /opt/sonatype/nexus/bin/nexus.vmoptions
-RUN yum install -y openssl
+RUN dnf install -y openssl
 
 # Allow nexus to modify the logging properties for debugging purposes.
 RUN chown nexus:nexus /opt/sonatype/nexus/etc/logback/logback.xml


### PR DESCRIPTION
## Summary and Scope

Build the CSM Nexus image (Nexus and CSM Keycloak integration configuration) from the published Nexus image.  Because Nexus images are based on RHEL UBI we apply dnf updates here.    Push branch images into csm-docker/unstable and tag using the gitash and branch name.   Push images into csm-docker/stable when merged into main.  Image are tagged on a git tag event which will happen when a release is created in GH.

## Testing

### Tested on:

  * Wasp to ensure Nexus and the Keycloak authentication integration work as expected.  Confirmed the build pushes and tags images in Artifactory as necessary.  

## Risks and Mitigations

None. 

