### PR TITLE
CASMPET-5592: Deprecate Nexus3 Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-# Nexus3
+# This repo is deprecated
 
-Support for Sonatype Nexus Repository Manager 3 with the [Keycloak plugin](https://github.com/flytreeleft/nexus3-keycloak-plugin).
+For the nexus3 image see [Container Images](https://github.com/Cray-HPE/container-images/tree/main/docker.io/sonatype/nexus3)
 
-![Build image status](https://github.com/Cray-HPE/nexus3/actions/workflows/build-image.yaml/badge.svg?event=schedule)
+
+
+# ~~Nexus3
+
+~~Support for Sonatype Nexus Repository Manager 3 with the [Keycloak plugin](https://github.com/flytreeleft/nexus3-keycloak-plugin).
+
+~~![Build image status](https://github.com/Cray-HPE/nexus3/actions/workflows/build-image.yaml/badge.svg?event=schedule)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ For the nexus3 image see [Container Images](https://github.com/Cray-HPE/containe
 
 
 
-# ~~Nexus3
+## ~~Nexus3~~
 
-~~Support for Sonatype Nexus Repository Manager 3 with the [Keycloak plugin](https://github.com/flytreeleft/nexus3-keycloak-plugin).
+~~Support for Sonatype Nexus Repository Manager 3 with the [Keycloak plugin](https://github.com/flytreeleft/nexus3-keycloak-plugin).~~
 
-~~![Build image status](https://github.com/Cray-HPE/nexus3/actions/workflows/build-image.yaml/badge.svg?event=schedule)
+~~![Build image status](https://github.com/Cray-HPE/nexus3/actions/workflows/build-image.yaml/badge.svg?event=schedule)~~


### PR DESCRIPTION
## Summary and Scope

This updates the readme of the nexus3 repo as it no longer is needed and should not be used for updates. 

## Issues and Related PRs

* Resolves [CASMPET-5592](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5592)
* 
## Testing

### Test description:

No tests needed for a readme change

## Risks and Mitigations

Just readme change no risks involved


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

